### PR TITLE
Sf update manifest v3

### DIFF
--- a/Tasks/ServiceFabricUpdateManifestsV2/task.json
+++ b/Tasks/ServiceFabricUpdateManifestsV2/task.json
@@ -19,7 +19,7 @@
     ],
     "version": {
         "Major": 2,
-        "Minor": 198,
+        "Minor": 222,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",

--- a/Tasks/ServiceFabricUpdateManifestsV2/task.json
+++ b/Tasks/ServiceFabricUpdateManifestsV2/task.json
@@ -104,7 +104,8 @@
             "helpMarkDown": "The build for comparison.",
             "options": {
                 "LastSuccessful": "Last Successful Build",
-                "Specific": "Specific Build"
+                "Specific": "Specific Build",
+                "LatestFromBranch": "Last Successful Build from a specific Branch",
             },
             "visibleRule": "updateType = Manifest versions && updateOnlyChanged = true"
         },
@@ -116,6 +117,15 @@
             "required": false,
             "helpMarkDown": "The build number for comparison.",
             "visibleRule": "updateType = Manifest versions && compareType = Specific"
+        },
+        {
+            "name": "branchName",
+            "type": "string",
+            "label": "Branch Name",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The branch name to get the build for comparison.",
+            "visibleRule": "updateType = Manifest versions && compareType = LatestFromBranch"
         },
         {
             "name": "overwriteExistingPkgArtifact",


### PR DESCRIPTION
**Task name**:  ServiceFabricUpdateManifestV2

**Description**:  Updating manifest is done by comparing build outputs. I've added a build filter `LatestFromBranch` to be able to select the Latest, Succeeded Build from a Branch.

**Documentation changes required:** (Y/N) **Unsure**

**Added unit tests:** (Y/N) I've found no tests in this area, as it just leverages the Azure DevOps API.

**Attached related issue:** N  n/a

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected


 
